### PR TITLE
Fix zookeeper and publisher app image

### DIFF
--- a/mantis-stack/values.yaml
+++ b/mantis-stack/values.yaml
@@ -1,5 +1,9 @@
 zookeeper:
   fullnameOverride: zookeeper
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/zookeeper
+    tag: "3.8.2-debian-11-r21"
 
 mantis:
   ## kubernetes cluster domain name
@@ -17,4 +21,5 @@ mantis:
     ## if the publisher sample deployment should be created
     ##
     enabled: true
-    image: netflixoss/mantis-publisher-sample:latest
+    # TODO: Using :latest once we cut of the official release
+    image: netflixoss/mantis-publisher-sample:4.0.2-rc.3


### PR DESCRIPTION
1. bitnami moves all legacy image to https://hub.docker.com/r/bitnamilegacy/zookeeper/tags?name=3.8.2-debian-11-r21 after 08/28/2025, zookeeper fails to start due to image not found
- see details from https://github.com/bitnami/containers/issues/83267

2. fix publisher app image to point to the latest, the old image still using java 8 instead 17
- released from https://github.com/Netflix/mantis/tree/v4.0.2-rc.3
- we need update the tag to be latest once cut off an official release

@Andyz26 